### PR TITLE
Lesson02.6: Apply slide review (restructuring)

### DIFF
--- a/msml610/lectures_source/Lesson02.1-A_Map_of_Machine_Learning.smd
+++ b/msml610/lectures_source/Lesson02.1-A_Map_of_Machine_Learning.smd
@@ -2,13 +2,6 @@
 // course_title=MSML610: Advanced Machine Learning
 // lesson_title=L02.1: A Map of Machine Learning
 // slides_engine=typst
-// references=
-// - Burkov: "The Hundred-Page Machine Learning Book" (2019)
-// - Russell et al.: "Artificial Intelligence: A Modern Approach" (4th ed, 2020)
-// - Hastie et al.: "The Elements of Statistical Learning" (2nd ed, 2009)
-
-// Model assessment and selection
-// Hastie 7 (p. 238)
 
 # A Map of Machine Learning
 

--- a/msml610/lectures_source/Lesson02.2-ML_Paradigms.smd
+++ b/msml610/lectures_source/Lesson02.2-ML_Paradigms.smd
@@ -2,14 +2,6 @@
 // course_title=MSML610: Advanced Machine Learning
 // lesson_title=L02.2: Machine Learning Paradigms
 // slides_engine=typst
-// references=
-// - Burkov: "The Hundred-Page Machine Learning Book" (2019)
-// - Russell et al.: "Artificial Intelligence: A Modern Approach" (4th ed, 2020)
-// - Hastie et al.: "The Elements of Statistical Learning" (2nd ed, 2009)
-
-
-// Model assessment and selection
-// Hastie 7 (p. 238)
 
 # Machine Learning Paradigms
 

--- a/msml610/lectures_source/Lesson02.3-ML_Techniques_Input_Processing.smd
+++ b/msml610/lectures_source/Lesson02.3-ML_Techniques_Input_Processing.smd
@@ -2,14 +2,6 @@
 // course_title=MSML610: Advanced Machine Learning
 // lesson_title=L02.3: ML Techniques - Input Processing
 // slides_engine=typst
-// references=
-// - Burkov: "The Hundred-Page Machine Learning Book" (2019)
-// - Russell et al.: "Artificial Intelligence: A Modern Approach" (4th ed, 2020)
-// - Hastie et al.: "The Elements of Statistical Learning" (2nd ed, 2009)
-
-
-// Model assessment and selection
-// Hastie 7 (p. 238)
 
 ## Input Processing
 

--- a/msml610/lectures_source/Lesson02.4-ML_Techniques_Model_Learning.smd
+++ b/msml610/lectures_source/Lesson02.4-ML_Techniques_Model_Learning.smd
@@ -2,13 +2,6 @@
 // course_title=MSML610: Advanced Machine Learning
 // lesson_title=L02.4: ML Techniques - Model Learning
 // slides_engine=typst
-// references=
-// - Burkov: "The Hundred-Page Machine Learning Book" (2019)
-// - Russell et al.: "Artificial Intelligence: A Modern Approach" (4th ed, 2020)
-// - Hastie et al.: "The Elements of Statistical Learning" (2nd ed, 2009)
-
-// Model assessment and selection
-// Hastie 7 (p. 238)
 
 ## Learning Algorithms
 

--- a/msml610/lectures_source/Lesson02.5-ML_Techniques_Model_Evaluation.smd
+++ b/msml610/lectures_source/Lesson02.5-ML_Techniques_Model_Evaluation.smd
@@ -2,13 +2,6 @@
 // course_title=MSML610: Advanced Machine Learning
 // lesson_title=L02.5: ML Techniques - Model Evaluation
 // slides_engine=typst
-// references=
-// - Burkov: "The Hundred-Page Machine Learning Book" (2019)
-// - Russell et al.: "Artificial Intelligence: A Modern Approach" (4th ed, 2020)
-// - Hastie et al.: "The Elements of Statistical Learning" (2nd ed, 2009)
-
-// Model assessment and selection
-// Hastie 7 (p. 238)
 
 ## Performance Metrics
 

--- a/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
+++ b/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
@@ -2,13 +2,6 @@
 // course_title=MSML610: Advanced Machine Learning
 // lesson_title=L02.6: ML Techniques - How to Do Research
 // slides_engine=typst
-// references=
-// - Burkov: "The Hundred-Page Machine Learning Book" (2019)
-// - Russell et al.: "Artificial Intelligence: A Modern Approach" (4th ed, 2020)
-// - Hastie et al.: "The Elements of Statistical Learning" (2nd ed, 2009)
-
-// Model assessment and selection
-// Hastie 7 (p. 238)
 
 # How to Do Research
 
@@ -168,46 +161,44 @@
 * What If Out-Of-Sample Fit Is Poor?
 - @Problem@: the model performs well in sample ($E_{in} \approx 0$) but poorly out of
   sample ($E_{out} \gg E_{in}$)
-
-- **What does it mean?**
   - In-sample performance is optimistic
   - Model is overfitted and fails to generalize
 
-- **What do you do?**
-  - Run diagnostics before long-term projects
-  - Gain insight on what works/doesn't to improve performance
-    - E.g., bias-variance curves and learning curves
-
-- **How to fix?**
-  1. Training data
-     - Get more training data $\iff$ fixes high variance
-  2. Features
-     - Remove features $\iff$ fixes high variance
-     - Add features $\iff$ fixes high bias
-     - Add derived features (e.g., polynomial features) $\iff$ fixes high bias
-  3. Regularization
-     - Decrease regularization $\lambda$ $\iff$ fixes high bias
-     - Increase regularization $\lambda$ $\iff$ fixes high variance
+- @Solution@:
+  1. Run diagnostics
+     - Gain insight on what works/doesn't to improve performance before long-term
+       projects
+       - E.g., bias-variance curves, learning curves
+  2. Address the problem
+     - Training data
+       - Get more training data to fix high variance
+     - Features
+       - Remove features to fix high variance
+       - Add features to fix high bias
+       - Add derived features (e.g., polynomial features) to fix high bias
+     - Regularization
+       - Decrease regularization $\lambda$ to fix high bias
+       - Increase regularization $\lambda$ to fix high variance
 
 * Why Using a Lot of Data?
-- **Several studies** show that:
+- @Fact@: **Several studies** show that:
   - Different algorithms/models have remarkably similar performance
   - Increasing training set improves performance
 
-- **Consequence**
+- @Consequence@
   - High capacity model + massive training set = good performance
 
-- **Why**
-  - Using a high capacity model with many parameters (e.g., neural network)
+- @Intuition@
+  - Using a high capacity model with many parameters (e.g., neural network):
     $$
     E_{in} \approx 0
     $$
-    due to low bias (and high variance)
-  - A massive data set helps avoid overfitting
+    due to low bias (but it has high variance)
+  - A large data set helps avoid overfitting:
     $$
     E_{out} \approx E_{in}
     $$
-  - These two conditions together
+  - These two conditions together:
     $$
     E_{out} \approx E_{in} \approx 0 \implies E_{out} \approx 0
     $$
@@ -216,69 +207,65 @@
 - You have $m$ = 100M examples in data set: great!
 
 - @Cons@
-  - Scalability issue (slow, lots of compute)
-  - Require work on infrastructure
+  - Scalability issue (slow, lots of compute) $\to$ require work on infrastructure
 
 ::: columns
-:::: {.column width=55%}
-- **First step**:
-  - Plot learning curves (in-sample and out-of-sample performance) for
-    increasing
-    amount of data $m = 1k, 10k, 100k, 1M, ...$
-- **Next step**:
-  - If model has large bias
-    - Training and validation performance are similar at $1M$
-    - Next step: use more complex model rather than training on $100M$ instances
-  - If model has large variance
-    - Next step: use all $100M$ instances to train the model
+:::: {.column width=70%}
+
+- @Algorithm@:
+  1. Plot learning curves (in-sample and out-of-sample performance) for increasing
+     amount of data $m$ = 1k, 10k, 100k, 1M, ...
+  2. Diagnose the current situation
+  - If model has _large bias_
+    - Training and validation performance are similar at 1M
+    - Next step: use more complex model rather than training on 100M instances
+  - If model has _large variance_
+    - Next step: use all 100M instances to train the model
 ::::
-:::: {.column width=40%}
+:::: {.column width=30%}
 ![](msml610/lectures_source/figures/L02.6.Learning_curves.png)
 ::::
 :::
 
 * Right and Wrong Approach to Research
-- It is not clear how to prioritize the different possible tasks
+- @Problem@: It is rarely clear how to prioritize the different possible tasks
 
-- **Bad**
+- @Bad approach@
   1. Use gut feeling to choose a task
   2. Complete task
   3. Re-evaluate performance
 
-- **Good**
-  1. Build a simple algorithm
-     - Within 1 day
-  2. Set up performance evaluation
-     - Single number and bounds to improve
+- @Good approach@
+  1. Build a simple algorithm (within 1 day!)
+  2. Set up performance evaluation process
      - Use cross-validation
+     - Single number and bounds to improve
   3. Set up diagnostic tools
      - Compute learning and bias-variance curves
      - Understand issues before fixing (avoid premature optimization)
-  4. Review misclassified emails manually
-     - Identify features to improve performance
-     - E.g., what are types of misclassified emails?
-
-- Sometimes you just need to try approaches to see if they work
-  - E.g., use stemming software to equate words
+  4. Understand the problem (debug)
+     - Review misclassified emails manually: what are their types?
+  5. Sometimes you just need to try approaches to see if they work
 
 * Example: Spam Filter Classification
-- You use $N = 5$ words in an email to distinguish spam / non-spam emails using
+- You use $N$ = 5 fixed words in an email to distinguish spam / non-spam emails using
   logistic regression
-  - Words are `buy`, `now`, `deal`, `discount`, `your name`
+  - Words are `buy`, `now`, `deal`, `discount`, `<your name>`
 
-- @Goal@: improve classifier performance
-  1. **Collect more data**
-     - Honeypot project: fake email account to collect spam
-  2. **Use better features**
-     - Email routing info (spammers use unusual accounts, mask emails as
-       legitimate)
-  3. **Use better features from message body**
-  4. **Detect intentional misspellings**
+- @Goal@: **improve classifier performance**
+  1. _Collect more data_
+     - E.g., honeypot project: fake email account to collect spam
+  2. _Use better features_
+     - E.g., email routing info since spammers use unusual accounts, mask emails as
+       legitimate
+  3. _Use better features from message body_
+     - E.g., more words
+  4. _Detect intentional misspellings_
      - Spammers use misspelled words (e.g., `w4tch` for `watch`)
      - Use stemming software
 
-* Why We Do Things?
-- **Always, always, always:**
+* Why Do We Do Things?
+- @Fact@: **Always, always, always:**
   - Understand the purpose of the task
     - Ask: _"Why are we doing something?"_
   - Clarify goals and outcomes of the task
@@ -288,33 +275,31 @@
   - Prioritize tasks by importance and impact
 
 - @Example@
-  - Q: _"Why is the feedback being collected?"_
+  - Q: _"Why is the feedback being collected with surveys?"_
     - A: To improve product features and customer service
   - Q: _"What is the desired outcome?"_
     - A: To identify areas for improvement and innovation
-
-- @Example@
   - Q: _"Why is this campaign run?"_
     - A: To increase brand awareness or drive sales
   - Q: _"What are the specific goals?"_
     - A: Set target number of new leads or click-through rates
 
 * Summary of the Results, Next Steps
-- **Always have a summary of results**
-  - High-level map of discoveries
-    - E.g., "smoothing model coefficients helps"
-  - Highlight major findings
+- @Always have a summary of results@
+  - High-level list of discoveries / major findings
+    - E.g., "smoothing model coefficients helps the model"
   - Interpret results
     - E.g., _"Increase in sales likely due to new marketing strategy."_
   - Conclusions
     - Summarize data suggestions or confirmations
     - E.g., _"Hypothesis that user engagement increases retention is supported"_
 
-- **Always have a reference to detailed results**
-  - Provide quick insights before details
+- @Always have a reference to detailed results@
+  - Provide quick insights for executives before details
+  - TLDR;
 
-- **Always have next steps**
-  - What do you expect to happen?
+- @Always think about the next steps@
+  - What do you expect to happen from an experiment?
     - Like thinking $n$ moves ahead in chess
   - E.g., _"Next, conduct detailed analysis on demographics contributing most to
     sales growth"_
@@ -325,36 +310,39 @@
 ::: columns
 :::: {.column width=55%}
 
-- **Incremental Development**
+- @Incremental Development@
   - Each increment adds functional components
   - Require upfront planning to divide features meaningfully
   - Integration of increments can be complex
 
-- **Iterative Development**
+- @Iterative Development@
   - Each increment delivers usable system
   - Refine and improve product through repeated cycles
   - Get feedback
   - Uncover and adjust for unknown requirements
 
-- **Incremental $\gg$ Iterative**
+- @Incremental $\gg$ Iterative@
 
 ::::
 :::: {.column width=40%}
 
 ![](msml610/lectures_source/figures/L02.6.Monalisa_incremental.png){width=90%}
 
-\small _Incremental
+// TODO(ai_gp): Make the font smaller and centered
+_Incremental_
 
 \vspace{0.5cm}
 
 ![](msml610/lectures_source/figures/L02.6.Monalisa_iterative.png){width=90%}
 
-\small _Iterative_
+// TODO(ai_gp): Make the font smaller and centered
+_Iterative_
 
 \vspace{0.5cm}
 
 ![](msml610/lectures_source/figures/L02.6.Skateboard.png){width=90%}
 
-\small _Incremental vs Iterative_
+// TODO(ai_gp): Make the font smaller and centered
+_Incremental vs Iterative_
 ::::
 :::

--- a/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
+++ b/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
@@ -15,80 +15,74 @@
 ## Simple Is Better
 
 * Occam's Razor
-- **Simple is better**
+- @Fact@: **Simple is better**
   - _"The simplest model that fits the data is also the most plausible"_
     (Occam)
-
   - _"An explanation of the data should be as simple as possible, but not
     simpler"_ (Einstein?)
+  - You need to trim the model to the bare minimum necessary to explain the data
 
-- Corollary:
-  - Trim the model to the bare minimum necessary to explain the data
+- @Question@: What does **simple** and **better** mean?
+  - A model is _simple_ when it is one of few possible objects
+  - A model is _better_ means better out of sample performance
 
-- @Question@
-  - A model is simple when it is one of few possible objects
-
-- @Question@
-  - A model is better means better out of sample performance
-
-- **Why it's true**?
+- @Question@: **Why it's true**?
   - Less likely to fit a given data by coincidence
   - An event is more significant if it is unlikely (formalized in terms entropy)
 
 * What is a "simple model"?
-- An object is **simple** when it is one of few possible objects
+- @Definition@: An object is **simple** when it is one of few possible objects
 
-- @Examples@: 
+- @Examples@:
   - Polynomial of order 2 is simpler than order 17
     - More polynomials of order 17 than order 2, though both are infinite sets
-  - SVM (Support Vector Machine) characteristics:
-    - Separating hyperplane appears wiggly, but defined by few support vectors
+  - For SVM (Support Vector Machine) separating hyperplane appears wiggly
+    ("complex"?), but defined by few support vectors (simple)
 
-- **Measures of complexity**
+- @Definition@: There are many **measures of complexity**
   - Complexity of a single hypothesis $h$
     - E.g., polynomial order, MDL (describe hypothesis in bits), Kolmogorov
       complexity
   - Complexity of a hypothesis set $\calH$
     - E.g., VC dimension of the model
-  - Complexity of $h$ and $\calH$ related by counting:
+  - Complexity of both $h$ and $\calH$ are related by counting:
     - If you need $l$ bits to specify $h$, then $h$ is one of $2^l$ elements of
       set $\calH$
 
 * Model Soundness
-- **Model should tell a story**
+- @Model should tell a story@
   - You cannot blindly accept results of modeling
   - Ask: _"What criticisms would you give if the model was presented for the
     first time?"_
 
-- **Benchmark models**: compute performance if model outputs:
+- Compare model to a @benchmark@ by computing performance to a model that outputs:
   - Always 0 or 1
     - E.g., long-only model for stock predictions
   - Random results
     - E.g., bootstrap of null hypothesis "no prediction power"
 
-- **Perfect fit can mean nothing**, e.g.,
+- @Fact@: A **perfect fit can mean nothing**, e.g.,
   - Get 2 data points on a plane
     - Fit data with a linear relationship
-    - Perfect fit
-  - Means nothing since:
-    - Always a line between 2 points
-    - Data cannot falsify hypothesis
-  - The model (line) is too complex for data set (only 2 points)
+  - The perfect fit means nothing since: there is always a line between 2 points
+    - The model (line) is too complex for data set (only 2 points)
+  - Data cannot falsify hypothesis
 
 * Sampling Bias (1/2)
-- **Sampling bias** occurs when data is not representative of the intended
-  population
+- @Definition@: **Sampling bias** occurs when data is not representative of the
+  intended population
   - Biased sampling leads to biased outcomes
-  - Model views world through training data
-  - Hoeffding's hypothesis: training and testing distributions are the same
+    - The model views the world through training data
+  - Formalized by Hoeffding's hypothesis in ML theory: training and testing
+    distributions are the same
 
-- **Causes of Sampling Bias**
+- @Causes of Sampling Bias@
   - _Non-random sampling_: Favors certain outcomes or groups
   - _Undercoverage_: Inadequate representation of some population members
   - _Survivorship bias_: Includes only successful subjects
   - _Self-selection bias_: Participants choose to participate, introducing bias
 
-- **Consequences**
+- @Consequences@
   - Systematic errors distort relationships or predictions
   - Models trained on biased samples perform poorly on real-world data
   - Leads to incorrect or unfair decisions
@@ -100,27 +94,28 @@
   - Predicting income using data only from employed individuals omits unemployed
     people
 
-- **Mitigation**
+- @Mitigation@
   - Compare sample statistics with population statistics
   - Use stratified sampling or resampling to balance data
   - Apply re-weighting or bias correction techniques
   - If data points have zero probability ($\Pr = 0$), no remedies possible
 
 * Data Snooping (1/2)
-- **Data snooping** occurs when test set information improperly influences
-  model-building
+- @Definition@: **Data snooping** occurs when test set information improperly
+  influences model-building
 
-- **Typical Sources**
+- @Causes of Data Snooping@
   - _Train-test contamination_: Test data leaks into training
     - E.g., Using test data during feature engineering, model selection, or
       tuning
   - _Multiple hypothesis testing_: Trying many models inflates performance
+    - E.g., p-hacking but also more subtle phenomena
 
-- **Consequences**
+- @Consequences@
   - Overly optimistic evaluations
-  - Models perform well in validation but fail on unseen data
+  - Models perform well in validation / test, but fail on unseen data
 
-- **Why It's Dangerous**
+- @Why It's Dangerous@
   - Misleading results
   - False confidence in model quality
   - Common pitfall in machine learning workflows
@@ -131,25 +126,24 @@
     not present in deployment
   - E.g., demean the entire data and then split in train / test
 
-- **Preventive Strategies**
+- @Preventive Strategies@
   - Keep training, validation, and test sets separate
+    - Fit preprocessing steps only on training data, then apply to test data
   - Use cross-validation properly
-  - Fit preprocessing steps only on training data, then apply to test data
 
 * "Burning the Test Set"
 - @Problem@
-  - Repeated test set use during development leaks into training
-  - Overfitting to test data
+  - Repeated test set use during development leaks into training $\to$ overfitting to
+    _test data_
   - _"If you torture the data long enough, it will confess whatever you want"_
     (Coase, 1982)
 
-- **Symptoms**
-  - Test accuracy improves; real-world performance stagnates or degrades
-  - Model evaluation becomes untrustworthy
+- @Consequences@
+  - Test accuracy improves but (unknown) real performance stagnates / degrades
+  - You can't trust your own model evaluation process
 
-- **Solutions**
-  - _One-time use principle_: Evaluate on test set once, post-tuning
-  - _Use a validation set_: For model development and tuning
+- @Mitigation@
+  - _One-time use principle_: Evaluate on test set _once_ after all the tuning
   - _Statistical adjustments_:
     - Adjust p-values for multiple testing
     - Use Bonferroni or False Discovery Rate corrections
@@ -163,22 +157,17 @@
 * How to Achieve Out-Of-Sample Fit
 - @Goal@: Choose an hypothesis $g \in \calH$ approximates the unknown target
   function $f$
-  - What does $g \approx f$ mean?
-    $$
-    g \approx f \iff E_{out}(g) \approx 0
-    $$
+  - $g \approx f$ means $E_{out}(g) \approx 0$
 
 - @Solution@: 
-  - Achieve:
+  - Build a model that has:
     - Good in-sample performance $E_{in}(g) \approx 0$
     - Good generalization $E_{out}(g) \approx E_{in}(g)$
-  - Together $\implies$ good out-of-sample performance
-    $E_{out}(g) \approx 0$
+  - Together good out-of-sample performance $E_{out}(g) \approx 0$
 
 * What If Out-Of-Sample Fit Is Poor?
-- The model performs well in sample ($E_{in} \approx 0$) but poorly out of
-  sample
-  ($E_{out} \gg E_{in}$)
+- @Problem@: the model performs well in sample ($E_{in} \approx 0$) but poorly out of
+  sample ($E_{out} \gg E_{in}$)
 
 - **What does it mean?**
   - In-sample performance is optimistic

--- a/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
+++ b/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
@@ -10,9 +10,9 @@
 // Model assessment and selection
 // Hastie 7 (p. 238)
 
-## How to Do Research
+# How to Do Research
 
-### Simple Is Better
+## Simple Is Better
 
 * Occam's Razor
 - **Simple is better**
@@ -158,7 +158,7 @@
     - Minimum Description Length (MDL) penalizes complex models and repeated
       fitting
 
-### Research Methodology
+## Research Methodology
 
 * How to Achieve Out-Of-Sample Fit
 - @Goal@: Choose an hypothesis $g \in \calH$ approximates the unknown target
@@ -248,6 +248,46 @@
 ::::
 :::
 
+* Right and Wrong Approach to Research
+- It is not clear how to prioritize the different possible tasks
+
+- **Bad**
+  1. Use gut feeling to choose a task
+  2. Complete task
+  3. Re-evaluate performance
+
+- **Good**
+  1. Build a simple algorithm
+     - Within 1 day
+  2. Set up performance evaluation
+     - Single number and bounds to improve
+     - Use cross-validation
+  3. Set up diagnostic tools
+     - Compute learning and bias-variance curves
+     - Understand issues before fixing (avoid premature optimization)
+  4. Review misclassified emails manually
+     - Identify features to improve performance
+     - E.g., what are types of misclassified emails?
+
+- Sometimes you just need to try approaches to see if they work
+  - E.g., use stemming software to equate words
+
+* Example: Spam Filter Classification
+- You use $N = 5$ words in an email to distinguish spam / non-spam emails using
+  logistic regression
+  - Words are `buy`, `now`, `deal`, `discount`, `your name`
+
+- @Goal@: improve classifier performance
+  1. **Collect more data**
+     - Honeypot project: fake email account to collect spam
+  2. **Use better features**
+     - Email routing info (spammers use unusual accounts, mask emails as
+       legitimate)
+  3. **Use better features from message body**
+  4. **Detect intentional misspellings**
+     - Spammers use misspelled words (e.g., `w4tch` for `watch`)
+     - Use stemming software
+
 * Why We Do Things?
 - **Always, always, always:**
   - Understand the purpose of the task
@@ -290,46 +330,6 @@
   - E.g., _"Next, conduct detailed analysis on demographics contributing most to
     sales growth"_
     - Outline potential experiments or analyses to validate findings further
-
-* Example: Spam Filter Classification
-- You use $N = 5$ words in an email to distinguish spam / non-spam emails using
-  logistic regression
-  - Words are `buy`, `now`, `deal`, `discount`, `your name`
-
-- @Goal@: improve classifier performance
-  1. **Collect more data**
-     - Honeypot project: fake email account to collect spam
-  2. **Use better features**
-     - Email routing info (spammers use unusual accounts, mask emails as
-       legitimate)
-  3. **Use better features from message body**
-  4. **Detect intentional misspellings**
-     - Spammers use misspelled words (e.g., `w4tch` for `watch`)
-     - Use stemming software
-
-* Right and Wrong Approach to Research
-- It is not clear how to prioritize the different possible tasks
-
-- **Bad**
-  1. Use gut feeling to choose a task
-  2. Complete task
-  3. Re-evaluate performance
-
-- **Good**
-  1. Build a simple algorithm
-     - Within 1 day
-  2. Set up performance evaluation
-     - Single number and bounds to improve
-     - Use cross-validation
-  3. Set up diagnostic tools
-     - Compute learning and bias-variance curves
-     - Understand issues before fixing (avoid premature optimization)
-  4. Review misclassified emails manually
-     - Identify features to improve performance
-     - E.g., what are types of misclassified emails?
-
-- Sometimes you just need to try approaches to see if they work
-  - E.g., use stemming software to equate words
 
 * Incremental vs Iterative
 


### PR DESCRIPTION
Part 1/3 of a stacked PR chain for Lesson02.6 slide polish.

- Fix section heading levels (## -> #, ### -> ##) per slides.rules.md
- Reorder Research Methodology slides: move "Right and Wrong Approach to Research" and its worked example "Example: Spam Filter Classification" ahead of the mindset/summary slides; "Incremental vs Iterative" stays last
- No content added, removed, or reworded

Tracks #551. Next: PR2 (visuals + references) stacks on this branch, PR3 (render) stacks on PR2.