### PR TITLE
Lesson02.6: Render (fix citation syntax and page overflow)

### DIFF
--- a/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
+++ b/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
@@ -50,9 +50,22 @@
       complexity
   - Complexity of a hypothesis set $\calH$
     - E.g., VC dimension of the model
+      [@abumostafa2012learning]
   - Complexity of $h$ and $\calH$ related by counting:
     - If you need $l$ bits to specify $h$, then $h$ is one of $2^l$ elements of
       set $\calH$
+
+\begingroup \footnotesize
+```{=typst}
+#styled-table(
+  headers: ("Complexity Of", "Measure", "Example"),
+  rows: (
+    ("Single hypothesis $h$", "Description length", "Polynomial order, MDL, Kolmogorov complexity"),
+    ("Hypothesis set $\calH$", "Capacity", "VC dimension"),
+  ),
+)
+```
+\endgroup
 
 * Model Soundness
 - **Model should tell a story**
@@ -81,12 +94,27 @@
   - Biased sampling leads to biased outcomes
   - Model views world through training data
   - Hoeffding's hypothesis: training and testing distributions are the same
+    [@abumostafa2012learning]
 
 - **Causes of Sampling Bias**
   - _Non-random sampling_: Favors certain outcomes or groups
   - _Undercoverage_: Inadequate representation of some population members
   - _Survivorship bias_: Includes only successful subjects
   - _Self-selection bias_: Participants choose to participate, introducing bias
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#EEEDFE', 'primaryBorderColor': '#7F77DD', 'primaryTextColor': '#26215C', 'lineColor': '#888888', 'fontFamily': 'Helvetica'}}}%%
+mindmap
+  root((**Sampling Bias**))
+    (**Non-random sampling**)
+      Favors certain outcomes
+    (**Undercoverage**)
+      Inadequate representation
+    (**Survivorship bias**)
+      Only successful subjects
+    (**Self-selection bias**)
+      Participants opt in
+```
 
 - **Consequences**
   - Systematic errors distort relationships or predictions
@@ -109,6 +137,7 @@
 * Data Snooping (1/2)
 - **Data snooping** occurs when test set information improperly influences
   model-building
+  [@hastie2009statlearn]
 
 - **Typical Sources**
   - _Train-test contamination_: Test data leaks into training
@@ -136,8 +165,20 @@
   - Use cross-validation properly
   - Fit preprocessing steps only on training data, then apply to test data
 
+\begingroup \footnotesize
+```{=typst}
+#styled-table(
+  headers: ("Source", "Preventive Strategy"),
+  rows: (
+    ("Train-test contamination", "Keep training, validation, and test sets separate"),
+    ("Multiple hypothesis testing", "Use cross-validation properly; fit preprocessing on training data only"),
+  ),
+)
+```
+\endgroup
+
 * "Burning the Test Set"
-- @Problem@
+- @Problem@ [@hastie2009statlearn]
   - Repeated test set use during development leaks into training
   - Overfitting to test data
   - _"If you torture the data long enough, it will confess whatever you want"_
@@ -163,6 +204,7 @@
 * How to Achieve Out-Of-Sample Fit
 - @Goal@: Choose an hypothesis $g \in \calH$ approximates the unknown target
   function $f$
+  [@abumostafa2012learning]
   - What does $g \approx f$ mean?
     $$
     g \approx f \iff E_{out}(g) \approx 0
@@ -179,6 +221,7 @@
 - The model performs well in sample ($E_{in} \approx 0$) but poorly out of
   sample
   ($E_{out} \gg E_{in}$)
+  [@abumostafa2012learning]
 
 - **What does it mean?**
   - In-sample performance is optimistic
@@ -200,8 +243,23 @@
      - Decrease regularization $\lambda$ $\iff$ fixes high bias
      - Increase regularization $\lambda$ $\iff$ fixes high variance
 
+\begingroup \footnotesize
+```{=typst}
+#styled-table(
+  headers: ("Lever", "Action", "Effect"),
+  rows: (
+    ("Training data", "Get more data", "Fixes high variance"),
+    ("Features", "Remove features", "Fixes high variance"),
+    ("Features", "Add (derived) features", "Fixes high bias"),
+    ("Regularization", "Decrease $\lambda$", "Fixes high bias"),
+    ("Regularization", "Increase $\lambda$", "Fixes high variance"),
+  ),
+)
+```
+\endgroup
+
 * Why Using a Lot of Data?
-- **Several studies** show that:
+- **Several studies** show that: [@abumostafa2012learning]
   - Different algorithms/models have remarkably similar performance
   - Increasing training set improves performance
 
@@ -251,10 +309,16 @@
 * Right and Wrong Approach to Research
 - It is not clear how to prioritize the different possible tasks
 
+::: columns
+:::: {.column width=45%}
+
 - **Bad**
   1. Use gut feeling to choose a task
   2. Complete task
   3. Re-evaluate performance
+
+::::
+:::: {.column width=55%}
 
 - **Good**
   1. Build a simple algorithm
@@ -268,6 +332,9 @@
   4. Review misclassified emails manually
      - Identify features to improve performance
      - E.g., what are types of misclassified emails?
+
+::::
+:::
 
 - Sometimes you just need to try approaches to see if they work
   - E.g., use stemming software to equate words

--- a/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
+++ b/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
@@ -45,27 +45,23 @@
     - Separating hyperplane appears wiggly, but defined by few support vectors
 
 - **Measures of complexity**
-  - Complexity of a single hypothesis $h$
-    - E.g., polynomial order, MDL (describe hypothesis in bits), Kolmogorov
-      complexity
-  - Complexity of a hypothesis set $\calH$
-    - E.g., VC dimension of the model
-      [@abumostafa2012learning]
   - Complexity of $h$ and $\calH$ related by counting:
     - If you need $l$ bits to specify $h$, then $h$ is one of $2^l$ elements of
       set $\calH$
 
-\begingroup \footnotesize
 ```{=typst}
 #styled-table(
   headers: ("Complexity Of", "Measure", "Example"),
   rows: (
-    ("Single hypothesis $h$", "Description length", "Polynomial order, MDL, Kolmogorov complexity"),
-    ("Hypothesis set $\calH$", "Capacity", "VC dimension"),
+    (
+      "Single hypothesis", "Description length",
+      "Polynomial order, MDL, Kolmogorov complexity",
+    ),
+    ("Hypothesis set", "Capacity", "VC dimension"),
   ),
+  caption: [#cite("abumostafa2012learning")],
 )
 ```
-\endgroup
 
 * Model Soundness
 - **Model should tell a story**
@@ -94,15 +90,11 @@
   - Biased sampling leads to biased outcomes
   - Model views world through training data
   - Hoeffding's hypothesis: training and testing distributions are the same
-    [@abumostafa2012learning]
+    `#cite("abumostafa2012learning")`{=typst}
 
 - **Causes of Sampling Bias**
-  - _Non-random sampling_: Favors certain outcomes or groups
-  - _Undercoverage_: Inadequate representation of some population members
-  - _Survivorship bias_: Includes only successful subjects
-  - _Self-selection bias_: Participants choose to participate, introducing bias
 
-```mermaid
+```mermaid[width=45%]
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#EEEDFE', 'primaryBorderColor': '#7F77DD', 'primaryTextColor': '#26215C', 'lineColor': '#888888', 'fontFamily': 'Helvetica'}}}%%
 mindmap
   root((**Sampling Bias**))
@@ -136,8 +128,7 @@ mindmap
 
 * Data Snooping (1/2)
 - **Data snooping** occurs when test set information improperly influences
-  model-building
-  [@hastie2009statlearn]
+  model-building `#cite("hastie2009statlearn")`{=typst}
 
 - **Typical Sources**
   - _Train-test contamination_: Test data leaks into training
@@ -170,15 +161,21 @@ mindmap
 #styled-table(
   headers: ("Source", "Preventive Strategy"),
   rows: (
-    ("Train-test contamination", "Keep training, validation, and test sets separate"),
-    ("Multiple hypothesis testing", "Use cross-validation properly; fit preprocessing on training data only"),
+    (
+      "Train-test contamination",
+      "Keep training, validation, and test sets separate",
+    ),
+    (
+      "Multiple hypothesis testing",
+      "Use cross-validation properly; fit preprocessing on training data only",
+    ),
   ),
 )
 ```
 \endgroup
 
 * "Burning the Test Set"
-- @Problem@ [@hastie2009statlearn]
+- @Problem@ `#cite("hastie2009statlearn")`{=typst}
   - Repeated test set use during development leaks into training
   - Overfitting to test data
   - _"If you torture the data long enough, it will confess whatever you want"_
@@ -203,8 +200,7 @@ mindmap
 
 * How to Achieve Out-Of-Sample Fit
 - @Goal@: Choose an hypothesis $g \in \calH$ approximates the unknown target
-  function $f$
-  [@abumostafa2012learning]
+  function $f$ `#cite("abumostafa2012learning")`{=typst}
   - What does $g \approx f$ mean?
     $$
     g \approx f \iff E_{out}(g) \approx 0
@@ -220,8 +216,7 @@ mindmap
 * What If Out-Of-Sample Fit Is Poor?
 - The model performs well in sample ($E_{in} \approx 0$) but poorly out of
   sample
-  ($E_{out} \gg E_{in}$)
-  [@abumostafa2012learning]
+  ($E_{out} \gg E_{in}$) `#cite("abumostafa2012learning")`{=typst}
 
 - **What does it mean?**
   - In-sample performance is optimistic
@@ -243,23 +238,8 @@ mindmap
      - Decrease regularization $\lambda$ $\iff$ fixes high bias
      - Increase regularization $\lambda$ $\iff$ fixes high variance
 
-\begingroup \footnotesize
-```{=typst}
-#styled-table(
-  headers: ("Lever", "Action", "Effect"),
-  rows: (
-    ("Training data", "Get more data", "Fixes high variance"),
-    ("Features", "Remove features", "Fixes high variance"),
-    ("Features", "Add (derived) features", "Fixes high bias"),
-    ("Regularization", "Decrease $\lambda$", "Fixes high bias"),
-    ("Regularization", "Increase $\lambda$", "Fixes high variance"),
-  ),
-)
-```
-\endgroup
-
 * Why Using a Lot of Data?
-- **Several studies** show that: [@abumostafa2012learning]
+- **Several studies** show that: `#cite("abumostafa2012learning")`{=typst}
   - Different algorithms/models have remarkably similar performance
   - Increasing training set improves performance
 
@@ -302,7 +282,7 @@ mindmap
     - Next step: use all $100M$ instances to train the model
 ::::
 :::: {.column width=40%}
-![](msml610/lectures_source/figures/L02.6.Learning_curves.png)
+![](msml610/lectures_source/figures/L02.6.Learning_curves.png){width=90%}
 ::::
 :::
 
@@ -436,3 +416,10 @@ mindmap
 \small _Incremental vs Iterative_
 ::::
 :::
+
+* References
+
+```{=typst}
+#set text(size: 0.75em)
+#references("/msml610/lectures_source/refs.bib")
+```

--- a/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
+++ b/msml610/lectures_source/Lesson02.6-ML_Techniques_How_To_Do_Research.smd
@@ -10,9 +10,9 @@
 // Model assessment and selection
 // Hastie 7 (p. 238)
 
-## How to Do Research
+# How to Do Research
 
-### Simple Is Better
+## Simple Is Better
 
 * Occam's Razor
 - **Simple is better**
@@ -158,7 +158,7 @@
     - Minimum Description Length (MDL) penalizes complex models and repeated
       fitting
 
-### Research Methodology
+## Research Methodology
 
 * How to Achieve Out-Of-Sample Fit
 - @Goal@: Choose an hypothesis $g \in \calH$ approximates the unknown target
@@ -248,6 +248,46 @@
 ::::
 :::
 
+* Right and Wrong Approach to Research
+- It is not clear how to prioritize the different possible tasks
+
+- **Bad**
+  1. Use gut feeling to choose a task
+  2. Complete task
+  3. Re-evaluate performance
+
+- **Good**
+  1. Build a simple algorithm
+     - Within 1 day
+  2. Set up performance evaluation
+     - Single number and bounds to improve
+     - Use cross-validation
+  3. Set up diagnostic tools
+     - Compute learning and bias-variance curves
+     - Understand issues before fixing (avoid premature optimization)
+  4. Review misclassified emails manually
+     - Identify features to improve performance
+     - E.g., what are types of misclassified emails?
+
+- Sometimes you just need to try approaches to see if they work
+  - E.g., use stemming software to equate words
+
+* Example: Spam Filter Classification
+- You use $N = 5$ words in an email to distinguish spam / non-spam emails using
+  logistic regression
+  - Words are `buy`, `now`, `deal`, `discount`, `your name`
+
+- @Goal@: improve classifier performance
+  1. **Collect more data**
+     - Honeypot project: fake email account to collect spam
+  2. **Use better features**
+     - Email routing info (spammers use unusual accounts, mask emails as
+       legitimate)
+  3. **Use better features from message body**
+  4. **Detect intentional misspellings**
+     - Spammers use misspelled words (e.g., `w4tch` for `watch`)
+     - Use stemming software
+
 * Why We Do Things?
 - **Always, always, always:**
   - Understand the purpose of the task
@@ -290,46 +330,6 @@
   - E.g., _"Next, conduct detailed analysis on demographics contributing most to
     sales growth"_
     - Outline potential experiments or analyses to validate findings further
-
-* Example: Spam Filter Classification
-- You use $N = 5$ words in an email to distinguish spam / non-spam emails using
-  logistic regression
-  - Words are `buy`, `now`, `deal`, `discount`, `your name`
-
-- @Goal@: improve classifier performance
-  1. **Collect more data**
-     - Honeypot project: fake email account to collect spam
-  2. **Use better features**
-     - Email routing info (spammers use unusual accounts, mask emails as
-       legitimate)
-  3. **Use better features from message body**
-  4. **Detect intentional misspellings**
-     - Spammers use misspelled words (e.g., `w4tch` for `watch`)
-     - Use stemming software
-
-* Right and Wrong Approach to Research
-- It is not clear how to prioritize the different possible tasks
-
-- **Bad**
-  1. Use gut feeling to choose a task
-  2. Complete task
-  3. Re-evaluate performance
-
-- **Good**
-  1. Build a simple algorithm
-     - Within 1 day
-  2. Set up performance evaluation
-     - Single number and bounds to improve
-     - Use cross-validation
-  3. Set up diagnostic tools
-     - Compute learning and bias-variance curves
-     - Understand issues before fixing (avoid premature optimization)
-  4. Review misclassified emails manually
-     - Identify features to improve performance
-     - E.g., what are types of misclassified emails?
-
-- Sometimes you just need to try approaches to see if they work
-  - E.g., use stemming software to equate words
 
 * Incremental vs Iterative
 

--- a/msml610/lectures_source/refs.bib
+++ b/msml610/lectures_source/refs.bib
@@ -310,3 +310,11 @@
   year   = {2023},
   url    = {https://futureoflife.org/open-letter/pause-giant-ai-experiments/}
 }
+
+@book{hastie2009statlearn,
+  author    = {Hastie, Trevor and Tibshirani, Robert and Friedman, Jerome},
+  title     = {The Elements of Statistical Learning: Data Mining, Inference, and Prediction},
+  publisher = {Springer},
+  year      = {2009},
+  edition   = {2nd}
+}


### PR DESCRIPTION
Part 3/3 of a stacked PR chain for Lesson02.6 slide polish. Stacks on #554 (PR2).

- Fixed citations: this template's slides use a custom Typst citation system (`#cite("key")`/`#references(...)`), not pandoc's `[@key]` markdown syntax added in PR2 — that failed to compile ('label does not exist'). Converted all 7 citations and added the required '* References' slide.
- Fixed a math-in-table-string bug where `$h$`/`$\calH$` inside a styled-table cell rendered as literal text.
- Verified render end-to-end with `gen_slides.py`, reducing PDF page overflow from 24 to 22 pages (17 content slides + title + references) by removing prose now fully duplicated by its accompanying table/mindmap, and correctly sizing the mindmap/image.
- Reverted one table (bias/variance fix levers) that triggered a Typst `figure()`/Touying template-level page-break quirk unrelated to content amount (jumps to a fresh page even with >50% blank space remaining) — out of scope for a single-lecture PR to fix in the shared template.
- 3 pages of the remaining 22 are pre-existing content-density overflows on 2 slides, confirmed via render to be unrelated to any change in this PR chain (present with or without PR2's column layout).

Tracks #551. This closes out the 3-part stack.