### PR TITLE
UmdTask573_Standardize_executable_CLI_interfaces

### DIFF
--- a/audit_results.md
+++ b/audit_results.md
@@ -1,0 +1,177 @@
+# Audit: CLI Interface Flags for Input/Files
+
+## Summary
+
+- **Total scripts audited**: 90+ Python executables across `dev_scripts_umd_classes/`, `helpers_root/dev_scripts_helpers/`, `helpers_root/linters2/`
+- **Standard compliant** (`-i`/`--input` for single file, `-f`/`--files` for lists): ~40 scripts
+- **Deviating** (using `--input_file`, `--file`, `--in_file`, etc.): ~35 scripts
+- **Unrelated flags**: remainder (these don't use file input args)
+
+---
+
+## Standard Interface Definition
+
+### Single Input File
+- **Flags**: `-i` / `--input`
+- **Aliases**: `--input_file` (deprecated, migrate to `-i`/`--input`)
+- **Type**: string (file path or `-` for stdin)
+- **Example**: `script.py -i data.txt` or `script.py --input data.txt`
+
+### File List
+- **Flags**: `-f` / `--files`
+- **Type**: string or comma-separated list
+- **Example**: `script.py -f file1.txt,file2.txt` or `script.py -f file1.txt file2.txt`
+
+### Input Directory
+- **Flags**: `--input_dir`
+- **Type**: string (directory path)
+- **Used by**: scripts that process entire directories
+- **Example**: `compress_figures.py --input_dir ./images/`
+
+---
+
+## Scripts Currently Following Standard
+
+### Single Input (`-i`/`--input`)
+✅ Compliant (no action needed):
+- `traceback_to_cfile.py`
+- All `dockerized_*` scripts (8 scripts in `dockerize/`)
+- `clean_markdown.py`
+- `convert_pdf_to_md.py`
+- `md_to_speech.py`
+- `notes_to_pdf.py`
+- `preprocess_notes.py`
+- `count_words.py` (partially: has both `-i` and `--input_file`)
+- `pytest_failed.py`
+- `to_github.py`
+- And ~15 others in documentation/download subdirectories
+
+### File Lists (`-f`/`--files`)
+✅ Compliant (no action needed):
+- `gd_notebook.py` (-f / --files)
+- `old/linter/linter.py` (-f / --files)
+- `generate_videos/convert_png_to_movie.py` (--files)
+- `copy_across_clients.py` (--files)
+
+---
+
+## Scripts Deviating from Standard
+
+### Deviation Type 1: `--input_file` instead of `-i`/`--input`
+🔴 Needs migration:
+- `lesson_parser.py` → migrate to `-i`/`--input`
+- `reorder_python_code.py` → migrate to `-i`/`--input`
+- `split_in_files.py` → migrate to `-i`/`--input`
+- `github/sync_gh_issue_labels.py` → migrate to `-i`/`--input`
+- `github/dockerized_sync_gh_issue_labels.py` → migrate to `-i`/`--input`
+- `count_words.py` (conflicting: has `-i` AND `--input_file`) → standardize to `-i`/`--input`
+- `github/dockerized_sync_gh_repo_settings.py` → migrate to `-i`/`--input`
+
+### Deviation Type 2: `--file` or `--in_file` instead of `-i`/`--input`
+🔴 Needs migration:
+- `replace_latex.py` (--file) → migrate to `-i`/`--input`
+- `github/gh_migration/bulk_transfer_issues.py` (--file) → migrate to `-i`/`--input`
+- `notebooks/publish_notebook.py` (--file) → migrate to `-i`/`--input`
+- `github/set_secrets_and_variables.py` (--file) → migrate to `-i`/`--input`
+- `toml_merge.py` (--in_file) → migrate to `-i`/`--input`
+- `check_links.py` (--in_file) → migrate to `-i`/`--input`
+- `transform_pandoc_ast_to_typst.py` (--in_file) → migrate to `-i`/`--input`
+- `documentations/extract_from_md.py` (docs mention but not verified) → migrate to `-i`/`--input`
+- `llms/dockerized_llm_review.py` (-i / --in_file_path) → standardize to `-i`/`--input`
+
+### Deviation Type 3: `--file_name` or similar naming variants
+🔴 Needs migration:
+- `process_prof.py` (--file_name) → migrate to `-i`/`--input`
+- `google/to_local_dir.py` (--file_name) → use case specific, needs review
+- `notebooks/extract_notebook_images.py` (--in_notebook_filename) → use case specific, needs review
+
+### Deviation Type 4: `--from_file` instead of `-i`/`--input`
+🔴 Needs migration:
+- `diff_to_vimdiff.py` (--from_file) → migrate to `-i`/`--input`
+
+### Deviation Type 5: `--input_files` instead of `-f`/`--files`
+🔴 Needs migration:
+- `concatenate_pdfs.py` (--input_files) → migrate to `-f`/`--files`
+- `notebooks/add_toc_to_notebook.py` (--input_files) → migrate to `-f`/`--files`
+
+### Deviation Type 6: Directory input variants (need separate standard)
+⚠️ Review/normalize:
+- `compress_figures.py` (--input_dir)
+- `extract_gdoc_map.py` (--input_dir)
+- `convert_png_dir_to_movie.py` (--input_dir)
+- `notebooks/add_toc_to_notebook.py` (--input_dir) — also has --input_files
+- `generate_videos/create_presentation_video.py` (--in_dir)
+- `generate_videos/generate_synthesia_videos.py` (--in_dir)
+- `generate_videos/extract_png_from_ppt.py` (--in_file)
+- `documentation/encrypt_models/encrypt_model.py` (--input_dir)
+
+**Recommendation**: Standardize to `--input_dir` for directories
+
+---
+
+## Invoke Tasks (`.py` files with `@task` decorator)
+
+Need to audit:
+- `helpers_root/tasks.py` — check git-related tasks (git_branch_diff, etc.)
+- `msml610/tasks.py` — check course-specific tasks
+- `tasks.py` (root) — check repo-wide tasks
+
+**Common patterns observed**: Many invoke tasks use custom `--input`, `-f`, `--files` inconsistently.
+
+---
+
+## Standardization Strategy
+
+### Phase 1: Create shared utility (helpers_root/)
+Create `helpers_root/lib_cli_utils.py` with:
+- `add_input_file_arg()` — standardizes `-i`/`--input` across all scripts
+- `add_files_list_arg()` — standardizes `-f`/`--files` across all scripts
+- `add_input_dir_arg()` — standardizes `--input_dir` across all scripts
+
+### Phase 2: Migrate by directory (batch PRs)
+
+**Batch 1: UMD Classes root**
+- `dev_scripts_umd_classes/lesson_parser.py`
+
+**Batch 2: coding_tools/**
+- `reorder_python_code.py`
+- `split_in_files.py`
+- `toml_merge.py`
+- `diff_to_vimdiff.py`
+- `process_prof.py`
+
+**Batch 3: documentation/**
+- `replace_latex.py`
+- `check_links.py`
+- `transform_pandoc_ast_to_typst.py`
+- `count_words.py` (fix mixed flags)
+
+**Batch 4: github/**
+- `sync_gh_issue_labels.py`
+- `dockerized_sync_gh_issue_labels.py`
+- `dockerized_sync_gh_repo_settings.py`
+- `gh_migration/bulk_transfer_issues.py`
+- `set_secrets_and_variables.py`
+
+**Batch 5: notebooks/**
+- `publish_notebook.py`
+- `add_toc_to_notebook.py`
+- `extract_notebook_images.py`
+
+**Batch 6: llms/**
+- `dockerized_llm_review.py`
+
+**Batch 7: Directory inputs** (--input_dir normalization)
+- All scripts using `--input_dir`, `--in_dir` → standardize to `--input_dir`
+
+**Batch 8: Invoke tasks**
+- Audit and fix `tasks.py` files (if they use argparse internally)
+
+---
+
+## Notes
+
+- Some scripts use alternative input methods (`--from_pb`, `--from_latest_file`, `--from_scratch`) — these are OKAY, they're additional options
+- Mutually exclusive groups (e.g., `traceback_to_cfile.py`) are acceptable
+- Short flags like `-i`, `-f` and long flags `--input`, `--files` should always coexist (both forms)
+- Some scripts take custom arguments by design (e.g., `--output`, `-o` for output) — keep those unchanged

--- a/dev_scripts_umd_classes/lesson_parser.py
+++ b/dev_scripts_umd_classes/lesson_parser.py
@@ -9,7 +9,7 @@ Parse Markdown lesson files and iterate through slides, headers, and comments.
 # Usage Example
 
 - Parse a lesson file and print all extracted items:
-> lesson_parser.py --input_file /path/to/lesson.txt
+> lesson_parser.py -i /path/to/lesson.txt
 """
 
 import argparse
@@ -33,12 +33,7 @@ def _parse() -> argparse.ArgumentParser:
         description=__doc__,
         formatter_class=hparser.CustomHelpFormatter,
     )
-    parser.add_argument(
-        "--input_file",
-        type=str,
-        required=True,
-        help="Path to the lesson file to parse",
-    )
+    hparser.add_input_file_arg(parser)
     parser.add_argument(
         "--item_type",
         type=str,
@@ -67,7 +62,7 @@ def _main(parser: argparse.ArgumentParser) -> None:
     """
     args = parser.parse_args()
     hdbg.init_logger(verbosity=args.log_level, use_exec_path=True)
-    input_file = args.input_file
+    input_file = args.input
     item_type = args.item_type
     output_file = args.output_file
     hdbg.dassert_file_exists(

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,212 @@
+# Plan: Standardize Executable CLI Interfaces
+
+## Objective
+
+Unify CLI argument flags across all executables in the repository so developers can reliably chain scripts and remember argument syntax. Standard: `-i`/`--input` for single files, `-f`/`--files` for file lists, `--input_dir` for directories.
+
+---
+
+## Implementation Strategy
+
+### Step 1: Add Shared Utility Functions to `helpers/hparser.py`
+
+**File**: `helpers_root/helpers/hparser.py` (existing module; already has
+`add_bool_arg()`, `add_verbosity_arg()` following this exact pattern — add
+alongside them rather than creating a new file)
+
+**Functions**:
+```python
+def add_input_file_arg(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add standardized -i/--input for single file."""
+    parser.add_argument(
+        "-i",
+        "--input",
+        dest="input",
+        type=str,
+        required=True,
+        help="Input file (or '-' for stdin)"
+    )
+    return parser
+
+def add_files_list_arg(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add standardized -f/--files for file list."""
+    parser.add_argument(
+        "-f",
+        "--files",
+        dest="files",
+        type=str,
+        nargs="+",
+        required=True,
+        help="List of input files (space-separated or comma-separated)"
+    )
+    return parser
+
+def add_input_dir_arg(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add standardized --input_dir for directory input."""
+    parser.add_argument(
+        "--input_dir",
+        dest="input_dir",
+        type=str,
+        required=True,
+        help="Input directory path"
+    )
+    return parser
+```
+
+**Benefits**:
+- Single source of truth for CLI interface
+- Ensures consistency across all scripts
+- Easy to update standards in future
+
+---
+
+### Step 2: Update Scripts in Batches (1 PR per batch)
+
+**Batch Strategy**: One directory per PR to keep review tractable (max 3-5 scripts per PR)
+
+#### Batch 1: UMD Classes root scripts
+**PR**: `UmdTask_StandardizeCliInterfaces_Batch1_umd_classes`
+- Files to update:
+  - `dev_scripts_umd_classes/lesson_parser.py`: `--input_file` → `-i`/`--input`
+- Test coverage: check `lesson_parser.py` unit tests if any
+
+#### Batch 2: coding_tools/ directory
+**PR**: `UmdTask_StandardizeCliInterfaces_Batch2_coding_tools`
+- Files to update:
+  - `helpers_root/dev_scripts_helpers/coding_tools/reorder_python_code.py`
+  - `helpers_root/dev_scripts_helpers/coding_tools/split_in_files.py`
+  - `helpers_root/dev_scripts_helpers/coding_tools/toml_merge.py`
+  - `helpers_root/dev_scripts_helpers/coding_tools/diff_to_vimdiff.py`
+  - `helpers_root/dev_scripts_helpers/coding_tools/process_prof.py`
+- Note: Some scripts may be in `helpers_root/`, test via `helpers_root/` commands
+
+#### Batch 3: documentation/ directory
+**PR**: `UmdTask_StandardizeCliInterfaces_Batch3_documentation`
+- Files to update:
+  - `helpers_root/dev_scripts_helpers/documentation/replace_latex.py`
+  - `helpers_root/dev_scripts_helpers/documentation/check_links.py`
+  - `helpers_root/dev_scripts_helpers/documentation/transform_pandoc_ast_to_typst.py`
+  - `helpers_root/dev_scripts_helpers/documentation/count_words.py`
+
+#### Batch 4: github/ directory
+**PR**: `UmdTask_StandardizeCliInterfaces_Batch4_github`
+- Files to update:
+  - `helpers_root/dev_scripts_helpers/github/sync_gh_issue_labels.py`
+  - `helpers_root/dev_scripts_helpers/github/dockerized_sync_gh_issue_labels.py`
+  - `helpers_root/dev_scripts_helpers/github/dockerized_sync_gh_repo_settings.py`
+  - `helpers_root/dev_scripts_helpers/github/gh_migration/bulk_transfer_issues.py`
+  - `helpers_root/dev_scripts_helpers/github/set_secrets_and_variables.py`
+
+#### Batch 5: notebooks/ directory
+**PR**: `UmdTask_StandardizeCliInterfaces_Batch5_notebooks`
+- Files to update:
+  - `helpers_root/dev_scripts_helpers/notebooks/publish_notebook.py`
+  - `helpers_root/dev_scripts_helpers/notebooks/add_toc_to_notebook.py`
+  - `helpers_root/dev_scripts_helpers/notebooks/extract_notebook_images.py`
+
+#### Batch 6: llms/ directory
+**PR**: `UmdTask_StandardizeCliInterfaces_Batch6_llms`
+- Files to update:
+  - `helpers_root/dev_scripts_helpers/llms/dockerized_llm_review.py`
+
+#### Batch 7: Directory inputs normalization
+**PR**: `UmdTask_StandardizeCliInterfaces_Batch7_input_dir`
+- Files to update:
+  - All scripts using `--input_dir` or `--in_dir` → standardize to `--input_dir`
+  - Examples:
+    - `helpers_root/dev_scripts_helpers/documentation/compress_figures.py`
+    - `helpers_root/dev_scripts_helpers/documentation/extract_gdoc_map.py`
+    - `helpers_root/dev_scripts_helpers/generate_videos/`
+
+#### Batch 8: Invoke tasks (if applicable)
+**PR**: `UmdTask_StandardizeCliInterfaces_Batch8_invoke_tasks`
+- Files to audit:
+  - `helpers_root/tasks.py` (git-related tasks)
+  - `msml610/tasks.py`
+  - `tasks.py` (root)
+- Action: Check if invoke tasks use argparse internally; if so, standardize
+
+---
+
+## Steps for Each Batch
+
+### For Each Script:
+
+1. **Update argparse definition**
+   ```python
+   # OLD
+   parser.add_argument("--input_file", type=str, required=True)
+   
+   # NEW
+   from helpers.hparser import add_input_file_arg
+   parser = add_input_file_arg(parser)
+   ```
+
+2. **Update all call sites** within the same script
+   - Replace `args.input_file` → `args.input`
+   - Replace `args.file` → `args.input`
+   - etc.
+
+3. **Update unit tests**
+   - Grep for test invocations: `script.py --input_file` → `script.py -i` or `script.py --input`
+   - Update test assertions referencing old flag names
+
+4. **Test locally**
+   ```bash
+   # Run unit tests for affected modules
+   pytest helpers_root/test/test_<script_name>.py -v
+   ```
+
+5. **Create PR**
+   - Branch: `UmdTask_StandardizeCliInterfaces_Batch<N>_<directory>`
+   - Description: List which scripts were updated, summary of changes
+
+---
+
+## Rollback / Deprecation Strategy
+
+### Option 1: Immediate cutover (recommended for small script count)
+- Remove old flags entirely
+- Pros: Clean, no confusion
+- Cons: Breaking change if scripts are called externally
+
+### Option 2: Deprecation period (for widely-used scripts)
+- Keep old flags working but print warning: "Flag `--input_file` is deprecated, use `-i` or `--input` instead"
+- Set sunset date (e.g., 6 months)
+- Remove in final batch
+
+---
+
+## Success Criteria
+
+- [ ] All scripts in `dev_scripts_umd_classes/`, `helpers_root/dev_scripts_helpers/`, `helpers_root/linters2/` use standard flags
+- [ ] All unit tests updated and passing
+- [ ] No external documentation references old flags
+- [ ] Shared utility `lib_cli_utils.py` used in 80%+ of scripts
+- [ ] Developers can confidently use `-i`/`--input` and `-f`/`--files` everywhere
+
+---
+
+## Timeline
+
+- **Week 1**: Create `lib_cli_utils.py` + implement Batch 1–2
+- **Week 2**: Implement Batch 3–4
+- **Week 3**: Implement Batch 5–6
+- **Week 4**: Implement Batch 7–8 + final review
+
+---
+
+## Notes
+
+- Some scripts have legitimate alternative input methods (e.g., `--from_pb` for clipboard) — these are **kept** as additional options
+- Mutually exclusive argument groups are fine (e.g., `-i` vs `--from_latest_file`)
+- Output flags (`-o`, `--output`) are unchanged; this initiative focuses only on **input** arguments
+- If a script has special file-handling logic (e.g., glob patterns), document in help text
+
+---
+
+## References
+
+- Audit results: `audit_results.md`
+- Shared utility location: `helpers_root/lib_cli_utils.py` (to be created)
+- Test framework: pytest with `helpers_root/CLAUDE.md` conventions

--- a/tasks.md
+++ b/tasks.md
@@ -1,40 +1,57 @@
-### [x] Document the agentic auto_task engineering flow
+### [ ] Standardize executable CLI interfaces
 
-* Repo: umd_classes
+* Repo:
+- umd_classes
+- helpers
+
+* Execution type: GitHub
 
 * Problem
-- We built an agentic workflow (`auto_task` rules, template, skills) to run AI
-  coding agents end to end (spec -> branch -> PR) with minimal supervision, but
-  it is not documented anywhere outside the skill files themselves
-- We want 3 blog posts that explain the flow: what we have today and what we
-  plan to have once it is done
+- Executables across the repo use inconsistent flags for the same concept (input
+  file and file list), making scripts harder to chain and remember
+
+* Implementation Notes
+- Scope: audit these directories in both repos
+  - umd_classes: `dev_scripts_umd_classes/`
+  - helpers: `helpers_root/dev_scripts_helpers/`, `helpers_root/linters2/`
+- Invoke targets: check tasks in `tasks.py`, `msml610/tasks.py`,
+  `helpers_root/tasks.py`
+- Standard interface: `-i`/`--input` for single file, `-f`/`--files` for list
+- Shared utilities: place in `helpers_root/`, import from both repos
+- Batch strategy: one directory of scripts per PR (max ~3-5 scripts)
 
 * Solution
 
-- [x] PR1: Write `blog_posts/draft.My_agentic_engineering_flow.md`
-  - Find and review all the relevant info in the repo before writing
-  - Describe the available pieces of info in the repo:
-    - `.claude/skills/auto_task.rules.md` (conventions for creating, queuing,
-      executing an `auto_task`)
-    - `.claude/templates/auto_task.template.md` (problem/solution/PR plan format)
-  - Describe the tools and the workflow:
-    - Create a `tasks.md` (e.g., from `msml610/book/prompt.slides_and_book_flow.md`)
-      in the auto_task format
-    - Review it with `/auto_task.criticize tasks.md`
-    - Execute it with `/auto_task.execute_with_stacked_prs tasks.md` or
-      `/auto_task.execute_interactively tasks.md`
-  - Describe the auto_task skills (`mdm skill l auto_task`):
-    `auto_task.create_specs_from_todos`, `auto_task.criticize`,
-    `auto_task.execute_interactively`, `auto_task.execute_with_stacked_prs`
-  - Explain the `/pr.*` skills (`pr.get_ci_to_pass`, `pr.get_local_tests_to_pass`,
-    `pr.get_to_commit_state`)
-  - Cover both current state (what is implemented and used today) and planned
-    state (what is still missing / on the roadmap)
+- [x] Audit and document the standard interface
 
-- [x] PR2: Finish `blog_posts/draft.how_to.A_queue_of_AI_coding_agents.md`
-  - This is the canonical version; `blog_posts/draft.A_queue_of_AI_coding_agents.md`
-    is an older duplicate and is not touched by this task
-  - Complete the draft describing the async queue-of-agents workflow
+  **Plan:**
+  1. Scan all executables in `dev_scripts_umd_classes/`, `helpers_root/dev_scripts_helpers/`,
+     `helpers_root/linters2/` for argparse flags using grep/ast parsing
+  2. Audit invoke targets in `tasks.py`, `msml610/tasks.py`, `helpers_root/tasks.py` for
+     parameter inconsistency
+  3. Create `audit_results.md` with raw findings: script name, current flags, deviation type
+  4. Document standard: `-i`/`--input` (single), `-f`/`--files` (list), add to `plan.md`
+  5. Create `plan.md` with standardization strategy (e.g., shared utility in `helpers_root/`,
+     batch-by-directory rollout)
 
-- [x] PR3: Finish `blog_posts/draft.how_to.Stacked_PRs_for_agentic_developent.md`
-  - Complete the draft describing the stacked-PR workflow for agentic development
+- [-] Fix deviating scripts
+
+  **Plan:**
+  1. Create shared utility function in `helpers_root/helpers/hparser.py` for standardized arg handling ✓
+  2. Update Batch 1: `dev_scripts_umd_classes/lesson_parser.py` (--input_file → -i/--input)
+  3. Test locally and in CI
+  4. Update remaining batches (2-8) per PR strategy
+
+  **Progress:**
+  - [x] Added `add_input_file_arg()`, `add_files_list_arg()`, `add_input_dir_arg()` to hparser.py
+  - [x] Tested new functions locally (all pass)
+  - [x] Fix Batch 1 script: lesson_parser.py (--input_file → -i/--input)
+  - [ ] Fix remaining batches (2-8)
+    - Batch 2: coding_tools/ (5 scripts)
+    - Batch 3: documentation/ (4 scripts)
+    - Batch 4: github/ (5 scripts)
+    - Batch 5: notebooks/ (3 scripts)
+    - Batch 6: llms/ (1 script)
+    - Batch 7: input_dir normalization (5+ scripts)
+    - Batch 8: invoke tasks (if needed)
+


### PR DESCRIPTION
Standardize CLI argument flags across executables (Batch 1 of 8).

Fixes #573

**This PR (Batch 1):**
- Add shared utilities to `helpers_root/helpers/hparser.py`: `add_input_file_arg()`, `add_files_list_arg()`, `add_input_dir_arg()`
- Migrate `dev_scripts_umd_classes/lesson_parser.py`: `--input_file` → `-i`/`--input`

**Remaining batches** (separate PRs): coding_tools/, documentation/, github/, notebooks/, llms/, input_dir normalization, invoke tasks. See `plan.md` and `audit_results.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yrrFkt3hxfsEnoBcbiYW7